### PR TITLE
ci: use PAT for PSR push to bypass branch ruleset

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.ref_name }}
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - run: git reset --hard ${{ github.sha }}
 
@@ -32,7 +33,7 @@ jobs:
         id: release
         uses: python-semantic-release/python-semantic-release@v10.5.3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.RELEASE_TOKEN }}
           directory: python
           git_committer_name: "github-actions"
           git_committer_email: "actions@users.noreply.github.com"


### PR DESCRIPTION
Uses a fine-grained PAT (`RELEASE_TOKEN`) for the `actions/checkout` and PSR steps so the version-bump commit can push directly to `main`, bypassing the branch ruleset (which blocks `GITHUB_TOKEN` / `github-actions[bot]` from pushing without a PR).