### PR TITLE
ci: add workflow_dispatch trigger to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - "python/**"
+  workflow_dispatch:
 
 jobs:
   release:


### PR DESCRIPTION
Allows manually triggering the release workflow from the Actions UI.