### PR TITLE
feat: visualization framework, Darwin Sort GA overhaul, CLI cleanup

### DIFF
--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -199,3 +199,29 @@ class TestDarwinCommand:
     def test_crossover_rate_option_succeeds(self, runner):
         result = runner.invoke(cli, ["darwin", "--crossover-rate", "0.8", "--mutation-rate", "0.2", "3", "1", "2"])
         assert result.exit_code == 0, result.output
+
+
+
+class TestStalinVisualizeCommand:
+    def test_visualize_flag_succeeds(self, runner):
+        result = runner.invoke(cli, ["stalin", "-v", "5", "1", "9", "2", "8"])
+        assert result.exit_code == 0, result.output
+
+    def test_visualize_long_flag_succeeds(self, runner):
+        result = runner.invoke(cli, ["stalin", "--visualize", "3", "1", "2"])
+        assert result.exit_code == 0, result.output
+
+
+class TestDarwinVisualizeCommand:
+    def test_visualize_flag_succeeds(self, runner):
+        result = runner.invoke(cli, ["darwin", "-v", "3", "1", "2"])
+        assert result.exit_code == 0, result.output
+
+    def test_visualize_with_options_succeeds(self, runner):
+        result = runner.invoke(cli, [
+            "darwin", "-v",
+            "--max-generations", "50",
+            "--population-size", "20",
+            "3", "1", "2",
+        ])
+        assert result.exit_code == 0, result.output

--- a/python/tests/test_visualizer.py
+++ b/python/tests/test_visualizer.py
@@ -1,0 +1,155 @@
+"""Tests for the visualization framework and algorithm viz generators."""
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+from big_oh_no.visualizer import Action, VizFrame, run_visualization
+
+
+# ── VizFrame / Action basics ─────────────────────────────────────────────────
+
+def test_vizframe_defaults():
+    frame = VizFrame(bars=[1, 2, 3])
+    assert frame.highlighted == []
+    assert frame.action == Action.COMPARE
+    assert frame.label == ""
+    assert frame.log_line == ""
+
+
+def test_action_enum_values():
+    assert Action.ELIMINATE.value == "eliminate"
+    assert Action.DONE.value == "done"
+    assert Action.SHUFFLE.value == "shuffle"
+    assert Action.EVOLVE.value == "evolve"
+
+
+# ── run_visualization ─────────────────────────────────────────────────────────
+
+def test_run_visualization_returns_final_bars():
+    frames = iter([
+        VizFrame(bars=[3, 1, 2], highlighted=[0], action=Action.COMPARE, label="cmp"),
+        VizFrame(bars=[1, 2, 3], highlighted=[0, 1, 2], action=Action.DONE, label="done"),
+    ])
+    result = run_visualization(frames, algo_name="Test", delay=0, sound=False)
+    assert result == [1, 2, 3]
+
+
+def test_run_visualization_empty_frames():
+    result = run_visualization(iter([]), algo_name="Test", delay=0, sound=False)
+    assert result == []
+
+
+def test_run_visualization_single_frame():
+    frames = iter([
+        VizFrame(bars=[5], highlighted=[0], action=Action.DONE, label="done"),
+    ])
+    result = run_visualization(frames, algo_name="Test", delay=0, sound=False)
+    assert result == [5]
+
+
+def test_run_visualization_collects_log_lines():
+    """Log lines don't affect the return value — just verifying no crash."""
+    frames = iter([
+        VizFrame(bars=[2, 1], highlighted=[], action=Action.COMPARE, log_line="[dim]start[/dim]"),
+        VizFrame(bars=[1, 2], highlighted=[0, 1], action=Action.DONE, log_line="[green]done[/green]"),
+    ])
+    result = run_visualization(frames, algo_name="Test", delay=0, sound=False)
+    assert result == [1, 2]
+
+
+# ── Stalin Sort viz generator ─────────────────────────────────────────────────
+
+def test_stalin_sort_viz_produces_correct_result():
+    from big_oh_no.stalin_sort import stalin_sort_viz
+
+    result = {}
+    frames = list(stalin_sort_viz([5, 1, 9, 2, 8], result=result))
+
+    assert result["survivors"] == [5, 9]
+    assert result["eliminated"] == [1, 2, 8]
+
+    # Last frame should be DONE
+    assert frames[-1].action == Action.DONE
+    assert frames[-1].bars == [5, 9]
+
+
+def test_stalin_sort_viz_all_survive():
+    from big_oh_no.stalin_sort import stalin_sort_viz
+
+    result = {}
+    frames = list(stalin_sort_viz([1, 2, 3], result=result))
+
+    assert result["survivors"] == [1, 2, 3]
+    assert result["eliminated"] == []
+    assert frames[-1].action == Action.DONE
+
+
+def test_stalin_sort_viz_without_result_dict():
+    from big_oh_no.stalin_sort import stalin_sort_viz
+
+    frames = list(stalin_sort_viz([3, 1, 2]))
+    assert frames[-1].action == Action.DONE
+
+
+def test_stalin_sort_viz_has_eliminate_frames():
+    from big_oh_no.stalin_sort import stalin_sort_viz
+
+    frames = list(stalin_sort_viz([5, 1, 9]))
+    eliminate_frames = [f for f in frames if f.action == Action.ELIMINATE]
+    assert len(eliminate_frames) == 1  # only 1 is eliminated
+
+
+# ── Darwin Sort viz generator ─────────────────────────────────────────────────
+
+def test_darwin_sort_viz_produces_correct_result():
+    from big_oh_no.darwin_sort import darwin_sort_viz
+
+    result = {}
+    frames = list(darwin_sort_viz([3, 1, 2], max_generations=500, result=result))
+
+    assert result["sorted"] == [1, 2, 3]
+    assert result["converged"] is True
+    assert frames[-1].action == Action.DONE
+
+
+def test_darwin_sort_viz_single_element():
+    from big_oh_no.darwin_sort import darwin_sort_viz
+
+    result = {}
+    frames = list(darwin_sort_viz([7], result=result))
+
+    assert result["sorted"] == [7]
+    assert result["converged"] is True
+    assert len(frames) == 1
+    assert frames[0].action == Action.DONE
+
+
+def test_darwin_sort_viz_without_result_dict():
+    from big_oh_no.darwin_sort import darwin_sort_viz
+
+    frames = list(darwin_sort_viz([2, 1], max_generations=500))
+    assert frames[-1].action == Action.DONE
+
+
+def test_darwin_sort_viz_extinction():
+    from big_oh_no.darwin_sort import darwin_sort_viz
+
+    result = {}
+    frames = list(darwin_sort_viz(
+        [10, 9, 8, 7, 6, 5, 4, 3, 2, 1],
+        max_generations=1,
+        population_size=2,
+        result=result,
+    ))
+
+    # With only 1 generation and 2 individuals, convergence is near-impossible
+    assert frames[-1].action == Action.DONE
+    assert "sorted" in result
+
+
+def test_darwin_sort_viz_rejects_invalid_params():
+    from big_oh_no.darwin_sort import darwin_sort_viz
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        list(darwin_sort_viz([3, 1, 2], crossover_prob=0.8, mutation_prob=0.5))


### PR DESCRIPTION
## Changes

### Visualization framework
- New visualizer.py with animated bar charts and optional sound (pip install big-oh-no[viz])
- Each action type has its own colour and sound: eliminations drop an octave, comparisons play each value, sorted state sweeps ascending

### Stalin Sort
- --visualize / -v flag, viz generator, fixed comparison visual bug with duplicates
- Extracted shared helpers (_stalin_verdict, _stalin_results)

### Darwin Sort GA overhaul
- eaMuPlusLambda (built-in elitism), Kendall tau fitness, adaptive mutation (indpb=2/n)
- model_validator enforcing crossover+mutation<=1.0
- --visualize / -v flag showing evolution in real time
- Convergence: ~100% for n<=15 (was ~20% for n=9)

### CLI cleanup
- Early return pattern for --visualize paths, no duplicated display logic

### README
- Rewrote Darwin Sort section, added viz/sound columns to algorithms table
- Install section shows pip install big-oh-no[viz] option

### Tests
- 19 new tests for visualizer, viz generators, CLI --visualize paths
- 97 tests total, all passing